### PR TITLE
Adding Missing Await

### DIFF
--- a/__tests__/sanitizeDocumentList.test.js
+++ b/__tests__/sanitizeDocumentList.test.js
@@ -1,3 +1,4 @@
 const test = require('ava');
 
 test.todo('Migrate SanitizeDocumentList tests to this file');
+test.todo('Make sure async stuff is handled correctly for every logic path');

--- a/src/sanitizeDocumentList.js
+++ b/src/sanitizeDocumentList.js
@@ -69,7 +69,7 @@ async function sanitizeDocumentList(schema, options, docs) {
   const multi = _.isArrayLike(docs);
 
   if (!multi) {
-    sanitizeDocument(schema, options, docs);
+    await sanitizeDocument(schema, options, docs);
     return;
   }
 


### PR DESCRIPTION
Because this `await` statement was missing, when using the findOne hook, the code was moving forward before having the results of the authLevel check. Now it waits.